### PR TITLE
Fix IP assignment bug in tmuxvpn script

### DIFF
--- a/bin/executable_tmuxvpn.sh
+++ b/bin/executable_tmuxvpn.sh
@@ -6,8 +6,8 @@ TUNNEL="NO TUNNEL"
 ip link show | grep proton &> /dev/null
 
 if [[ $? -eq 0 ]]; then
-	IP= $(curl icanhazip.com)
-	TUNNEL="PROTONVPN: ${IP}"
+        IP=$(curl -s icanhazip.com)
+        TUNNEL="PROTONVPN: ${IP}"
 fi
 
 for x in {0..5}; do


### PR DESCRIPTION
## Summary
- fix IP variable assignment in `executable_tmuxvpn.sh` so it correctly captures the address

## Testing
- `bash -n bin/executable_tmuxvpn.sh`

------
https://chatgpt.com/codex/tasks/task_e_68501c00c6388321a36346b99a0fd238